### PR TITLE
Kalender vult het scherm en week/dag starten op 08:00

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { AppShell } from "@/components/layout/app-shell";
 import {
   Calendar,
@@ -49,7 +49,17 @@ const FOCUS_HOUR = 8;
 
 function scrollTimeGrid(el: HTMLDivElement | null, hour = FOCUS_HOUR, smooth = false) {
   if (!el) return;
-  el.scrollTo({ top: hour * HOUR_H, behavior: smooth ? "smooth" : "auto" });
+  const top = hour * HOUR_H;
+  const apply = () => el.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
+  apply();
+  let tries = 0;
+  const tick = () => {
+    if (!el.isConnected) return;
+    apply();
+    if (el.scrollHeight > el.clientHeight + 8 || tries++ >= 12) return;
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
 }
 
 type CalColor = { bar: string; soft: string; check: string; glow: string };
@@ -226,7 +236,7 @@ function WeekGrid({
   const nowMinutes = useNowMinutes();
   const labels = weekDayNames(locale, "short");
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR));
     return () => cancelAnimationFrame(id);
   }, [scrollRef]);
@@ -273,7 +283,7 @@ function WeekGrid({
         })}
       </div>
 
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         <div className="flex" style={{ minHeight: 24 * HOUR_H }}>
           <div className="relative w-14 shrink-0">
             {hours.map((h) => (
@@ -361,7 +371,7 @@ function DayGrid({
   const dayEvents = timedOnDay(events, date);
   const allDay = allDayOnDay(events, date);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR));
     return () => cancelAnimationFrame(id);
   }, [scrollRef]);
@@ -386,7 +396,7 @@ function DayGrid({
           })}
         </div>
       )}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         <div className="flex" style={{ minHeight: 24 * HOUR_H }}>
           <div className="w-16 shrink-0">
             {hours.map((h) => (
@@ -945,10 +955,10 @@ export default function CalendarPage() {
     loadEvents();
   }, [loadEvents]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (viewMode === "month") return;
     const frame = requestAnimationFrame(() => scrollTimeGrid(timeScrollRef.current));
-    const timer = window.setTimeout(() => scrollTimeGrid(timeScrollRef.current), 80);
+    const timer = window.setTimeout(() => scrollTimeGrid(timeScrollRef.current), 120);
     return () => {
       cancelAnimationFrame(frame);
       window.clearTimeout(timer);

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
 import { AppShell } from "@/components/layout/app-shell";
 import {
   Calendar,
@@ -22,12 +22,14 @@ import type { CalendarEvent } from "@/app/api/ha/calendar/route";
 import {
   addDays,
   allDayOnDay,
+  DEFAULT_HOUR_H,
   durationLabel,
   durationMinutes,
   eventEnd,
   eventStart,
   eventsOnDay,
   formatTime,
+  hourHeightForViewport,
   isSameDay,
   localeOf,
   looksLikeMeet,
@@ -44,22 +46,58 @@ import {
 
 type ViewMode = "week" | "month" | "day";
 
-const HOUR_H = 48;
 const FOCUS_HOUR = 8;
 
-function scrollTimeGrid(el: HTMLDivElement | null, hour = FOCUS_HOUR, smooth = false) {
+function scrollTimeGrid(el: HTMLDivElement | null, hour = FOCUS_HOUR, hourH = DEFAULT_HOUR_H, smooth = false) {
   if (!el) return;
-  const top = hour * HOUR_H;
-  const apply = () => el.scrollTo({ top, behavior: smooth ? "smooth" : "auto" });
+  const apply = () => {
+    const marker = el.querySelector<HTMLElement>(`[data-hour="${hour}"]`);
+    const top = marker ? marker.offsetTop : hour * hourH;
+    if (smooth) el.scrollTo({ top, behavior: "smooth" });
+    else el.scrollTop = top;
+  };
   apply();
   let tries = 0;
   const tick = () => {
     if (!el.isConnected) return;
     apply();
-    if (el.scrollHeight > el.clientHeight + 8 || tries++ >= 12) return;
+    const target = hour * hourH;
+    const overflowing = el.scrollHeight > el.clientHeight + 8;
+    const aligned = Math.abs(el.scrollTop - target) < 4;
+    if ((overflowing && aligned) || tries++ >= 20) return;
     requestAnimationFrame(tick);
   };
   requestAnimationFrame(tick);
+}
+
+function useHourHeight(scrollRef: RefObject<HTMLDivElement | null>) {
+  const [hourH, setHourH] = useState(DEFAULT_HOUR_H);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const update = () => setHourH(hourHeightForViewport(el.clientHeight));
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [scrollRef]);
+  return hourH;
+}
+
+function TimeGridScrollPort({
+  scrollRef,
+  children,
+}: {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  children: ReactNode;
+}) {
+  return (
+    <div className="relative min-h-0 flex-1">
+      <div ref={scrollRef} className="absolute inset-0 overflow-y-auto overscroll-contain">
+        {children}
+      </div>
+    </div>
+  );
 }
 
 type CalColor = { bar: string; soft: string; check: string; glow: string };
@@ -235,11 +273,12 @@ function WeekGrid({
   const now = new Date();
   const nowMinutes = useNowMinutes();
   const labels = weekDayNames(locale, "short");
+  const hourH = useHourHeight(scrollRef);
 
   useLayoutEffect(() => {
-    const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR));
+    const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR, hourH));
     return () => cancelAnimationFrame(id);
-  }, [scrollRef]);
+  }, [scrollRef, hourH]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-card border border-white/70 bg-white/40 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04]">
@@ -283,11 +322,11 @@ function WeekGrid({
         })}
       </div>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
-        <div className="flex" style={{ minHeight: 24 * HOUR_H }}>
+      <TimeGridScrollPort scrollRef={scrollRef}>
+        <div className="flex" style={{ minHeight: 24 * hourH }}>
           <div className="relative w-14 shrink-0">
             {hours.map((h) => (
-              <div key={h} className="relative" style={{ height: HOUR_H }}>
+              <div key={h} data-hour={h} className="relative" style={{ height: hourH }}>
                 {h > 0 && (
                   <span className="absolute -top-2.5 right-2 select-none text-[10px] text-gray-400 dark:text-gray-500">
                     {String(h).padStart(2, "0")}:00
@@ -303,14 +342,14 @@ function WeekGrid({
               <div
                 key={toDateKey(day)}
                 className={cn("relative flex-1 border-l border-white/40 dark:border-white/10", isToday && "bg-accent-purple/5")}
-                style={{ minHeight: 24 * HOUR_H }}
+                style={{ minHeight: 24 * hourH }}
                 onClick={() => onSelectDay(day)}
               >
                 {hours.map((h) => (
-                  <div key={h} className="absolute w-full border-t border-black/[0.04] dark:border-white/5" style={{ top: h * HOUR_H }} />
+                  <div key={h} className="absolute w-full border-t border-black/[0.04] dark:border-white/5" style={{ top: h * hourH }} />
                 ))}
                 {isToday && (
-                  <div className="pointer-events-none absolute z-20 flex w-full items-center" style={{ top: (nowMinutes / 60) * HOUR_H }}>
+                  <div className="pointer-events-none absolute z-20 flex w-full items-center" style={{ top: (nowMinutes / 60) * hourH }}>
                     <div className="-ml-1 h-2 w-2 shrink-0 rounded-full bg-accent-orange" />
                     <div className="h-px flex-1 bg-accent-orange" />
                   </div>
@@ -318,8 +357,8 @@ function WeekGrid({
                 {dayEvents.map((ev, ei) => {
                   const start = eventStart(ev);
                   const end = eventEnd(ev);
-                  const top = (minutesInDay(start) / 60) * HOUR_H;
-                  const height = Math.max(((end.getTime() - start.getTime()) / 60_000 / 60) * HOUR_H, 22);
+                  const top = (minutesInDay(start) / 60) * hourH;
+                  const height = Math.max(((end.getTime() - start.getTime()) / 60_000 / 60) * hourH, 22);
                   const color = colorMap[ev.entityId] ?? CAL_COLORS[0];
                   return (
                     <button
@@ -344,7 +383,7 @@ function WeekGrid({
             );
           })}
         </div>
-      </div>
+      </TimeGridScrollPort>
     </div>
   );
 }
@@ -370,11 +409,12 @@ function DayGrid({
   const isToday = isSameDay(date, now);
   const dayEvents = timedOnDay(events, date);
   const allDay = allDayOnDay(events, date);
+  const hourH = useHourHeight(scrollRef);
 
   useLayoutEffect(() => {
-    const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR));
+    const id = requestAnimationFrame(() => scrollTimeGrid(scrollRef.current, FOCUS_HOUR, hourH));
     return () => cancelAnimationFrame(id);
-  }, [scrollRef]);
+  }, [scrollRef, hourH]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-card border border-white/70 bg-white/40 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.04]">
@@ -396,11 +436,11 @@ function DayGrid({
           })}
         </div>
       )}
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
-        <div className="flex" style={{ minHeight: 24 * HOUR_H }}>
+      <TimeGridScrollPort scrollRef={scrollRef}>
+        <div className="flex" style={{ minHeight: 24 * hourH }}>
           <div className="w-16 shrink-0">
             {hours.map((h) => (
-              <div key={h} className="relative" style={{ height: HOUR_H }}>
+              <div key={h} data-hour={h} className="relative" style={{ height: hourH }}>
                 {h > 0 && (
                   <span className="absolute -top-2.5 right-3 select-none text-[11px] text-gray-400 dark:text-gray-500">
                     {String(h).padStart(2, "0")}:00
@@ -409,12 +449,12 @@ function DayGrid({
               </div>
             ))}
           </div>
-          <div className="relative flex-1 border-l border-white/40 dark:border-white/10" style={{ minHeight: 24 * HOUR_H }}>
+          <div className="relative flex-1 border-l border-white/40 dark:border-white/10" style={{ minHeight: 24 * hourH }}>
             {hours.map((h) => (
-              <div key={h} className="absolute w-full border-t border-black/[0.04] dark:border-white/5" style={{ top: h * HOUR_H }} />
+              <div key={h} className="absolute w-full border-t border-black/[0.04] dark:border-white/5" style={{ top: h * hourH }} />
             ))}
             {isToday && (
-              <div className="pointer-events-none absolute z-20 flex w-full items-center" style={{ top: (nowMinutes / 60) * HOUR_H }}>
+              <div className="pointer-events-none absolute z-20 flex w-full items-center" style={{ top: (nowMinutes / 60) * hourH }}>
                 <div className="-ml-1.5 h-2.5 w-2.5 shrink-0 rounded-full bg-accent-orange" />
                 <div className="h-px flex-1 bg-accent-orange" />
               </div>
@@ -422,8 +462,8 @@ function DayGrid({
             {dayEvents.map((ev, i) => {
               const start = eventStart(ev);
               const end = eventEnd(ev);
-              const top = (minutesInDay(start) / 60) * HOUR_H;
-              const height = Math.max(((end.getTime() - start.getTime()) / 60_000 / 60) * HOUR_H, 28);
+              const top = (minutesInDay(start) / 60) * hourH;
+              const height = Math.max(((end.getTime() - start.getTime()) / 60_000 / 60) * hourH, 28);
               const color = colorMap[ev.entityId] ?? CAL_COLORS[0];
               return (
                 <button
@@ -450,7 +490,7 @@ function DayGrid({
             })}
           </div>
         </div>
-      </div>
+      </TimeGridScrollPort>
     </div>
   );
 }
@@ -484,7 +524,7 @@ function AgendaSidebar({
   const dateLabel = date.toLocaleDateString(locale, { day: "numeric", month: "long", year: "numeric" });
 
   return (
-    <aside className="flex h-[28vh] min-h-0 w-full shrink-0 flex-col overflow-hidden rounded-card border border-white/70 bg-white/45 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.05] lg:h-full lg:w-[300px]">
+    <aside className="flex h-[28vh] min-h-0 w-full shrink-0 flex-col overflow-hidden rounded-card border border-white/70 bg-white/45 backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.05] lg:h-auto lg:min-h-0 lg:w-[300px]">
       <div className="flex items-start justify-between gap-3 px-4 pb-2 pt-4">
         <div>
           <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">{t("calendar.scheduled")}</h2>
@@ -905,8 +945,10 @@ export default function CalendarPage() {
   }
 
   function scrollToNow() {
+    const el = timeScrollRef.current;
     const hour = new Date().getHours();
-    scrollTimeGrid(timeScrollRef.current, hour < FOCUS_HOUR ? FOCUS_HOUR : hour, true);
+    const hourH = hourHeightForViewport(el?.clientHeight ?? 0);
+    scrollTimeGrid(el, hour < FOCUS_HOUR ? FOCUS_HOUR : hour, hourH, true);
   }
 
   function selectDay(day: Date) {
@@ -957,8 +999,10 @@ export default function CalendarPage() {
 
   useLayoutEffect(() => {
     if (viewMode === "month") return;
-    const frame = requestAnimationFrame(() => scrollTimeGrid(timeScrollRef.current));
-    const timer = window.setTimeout(() => scrollTimeGrid(timeScrollRef.current), 120);
+    const el = timeScrollRef.current;
+    const hourH = hourHeightForViewport(el?.clientHeight ?? 0);
+    const frame = requestAnimationFrame(() => scrollTimeGrid(el, FOCUS_HOUR, hourH));
+    const timer = window.setTimeout(() => scrollTimeGrid(timeScrollRef.current, FOCUS_HOUR, hourH), 120);
     return () => {
       cancelAnimationFrame(frame);
       window.clearTimeout(timer);
@@ -999,7 +1043,7 @@ export default function CalendarPage() {
 
   return (
     <AppShell activeTab="/calendar" contentNoScroll>
-      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden lg:flex-row lg:gap-3">
+      <div className="flex h-full min-h-0 flex-1 flex-col gap-2 overflow-hidden lg:flex-row lg:gap-3">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
           <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-2">

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -291,7 +291,8 @@ export function AppShell({
   return (
     <div
       className={cn(
-        "flex min-h-screen flex-col",
+        "flex flex-col",
+        contentNoScroll ? "h-dvh max-h-dvh overflow-hidden" : "min-h-screen",
         pageBackground
           ? "bg-white/85 dark:bg-black/50"
           : "bg-page-light dark:bg-dark-page",
@@ -459,7 +460,7 @@ export function AppShell({
       </div>
       )}
 
-      <div className="flex flex-1 overflow-hidden relative">
+      <div className={cn("relative flex flex-1 overflow-hidden", contentNoScroll && "min-h-0")}>
         {showSidebar && (
           <div
             className={cn(
@@ -473,7 +474,7 @@ export function AppShell({
         <main
           className={cn(
             "flex-1 px-4 py-4 min-w-0 transition-[margin] duration-200 sm:px-6",
-            contentNoScroll ? "flex flex-col overflow-hidden" : "overflow-auto",
+            contentNoScroll ? "flex min-h-0 flex-col overflow-hidden" : "overflow-auto",
             !contentNoScroll && contentScrollbarHidden && "scrollbar-hide",
             showSidebar && sidebarOpen && "ml-[88px]"
           )}

--- a/src/lib/calendar-utils.test.ts
+++ b/src/lib/calendar-utils.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { addDays, isSameDay, monthGridDays, startOfWeek, stepTime, toDateKey, visibleMonthDays } from "./calendar-utils";
+import {
+  addDays,
+  DEFAULT_HOUR_H,
+  hourHeightForViewport,
+  isSameDay,
+  MIN_HOUR_H,
+  monthGridDays,
+  startOfWeek,
+  stepTime,
+  toDateKey,
+  visibleMonthDays,
+} from "./calendar-utils";
 
 describe("calendar-utils", () => {
   it("starts the week on Monday", () => {
@@ -39,5 +50,11 @@ describe("calendar-utils", () => {
     expect(stepTime("00:00", -15)).toBe("23:45");
     expect(stepTime("23:45", 15)).toBe("00:00");
     expect(stepTime("11:30", 90)).toBe("13:00");
+  });
+
+  it("scales hour rows to fit a workday in the viewport", () => {
+    expect(hourHeightForViewport(0)).toBe(DEFAULT_HOUR_H);
+    expect(hourHeightForViewport(700)).toBe(50);
+    expect(hourHeightForViewport(200)).toBe(MIN_HOUR_H);
   });
 });

--- a/src/lib/calendar-utils.ts
+++ b/src/lib/calendar-utils.ts
@@ -113,3 +113,16 @@ export function stepTime(value: string, deltaMinutes: number): string {
   const total = (((h * 60 + m + deltaMinutes) % 1440) + 1440) % 1440;
   return `${String(Math.floor(total / 60)).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
 }
+
+/** Default hour row height, used before the time grid has been measured. */
+export const DEFAULT_HOUR_H = 48;
+/** Floor so timed events stay tappable on small screens. */
+export const MIN_HOUR_H = 36;
+/** Typical workday length shown without scrolling (08:00–22:00). */
+export const VISIBLE_DAY_HOURS = 14;
+
+/** Scale hour rows so ~14 hours fit in the visible time-grid viewport. */
+export function hourHeightForViewport(clientHeight: number): number {
+  if (clientHeight <= 0) return DEFAULT_HOUR_H;
+  return Math.max(MIN_HOUR_H, Math.round(clientHeight / VISIBLE_DAY_HOURS));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Week- en dagweergave starten nu op 08:00, en de kalender blijft binnen het scherm.

## Waarom
De eerdere kalender-PR is al gemerged, maar week/dag openden nog op middernacht en de pagina vroeg te veel scrollen.

## Wat erin zit
- Tijdlijn opent op **08:00** (middernacht blijft bereikbaar door omhoog te scrollen)
- Uurrijen schalen mee met de schermhoogte, zodat een werkdag (~08:00–22:00) in beeld past
- Maandweergave en sidebar vullen het venster; alleen de tijdlijn zelf scrollt
- Knop **Nu** springt naar het huidige uur (of 08:00 als het nog vroeger is)

## Testen
1. Open Kalender (tab aanzetten in Instellingen indien nodig)
2. Maandweergave: geen paginascroll nodig
3. Week en Dag: 08:00 staat bovenaan
4. Knop **Nu** scrollt naar het huidige uur

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c21d976-e6e4-472c-b5b0-0526a5aa270d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c21d976-e6e4-472c-b5b0-0526a5aa270d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

