### PR TITLE
Temporarily hide several card types from the add picker

### DIFF
--- a/src/app/dashboards/[id]/page.tsx
+++ b/src/app/dashboards/[id]/page.tsx
@@ -76,6 +76,7 @@ import { getEditModeAllowed, getEditModePasscode, checkEditModePasscode } from "
 import { OfflinePill } from "@/components/offline-pill";
 import { useTranslation } from "@/hooks/use-translation";
 import { cn, generateId } from "@/lib/utils";
+import { isWidgetTypeTemporarilyDisabled } from "@/lib/disabled-widget-types";
 
 /** Alleen deze types kunnen als tile worden toegevoegd (floating cards). */
 const ADDABLE_WIDGET_TYPES = ["text_card", "climate_card_2", "light_card", "media_card", "solar_card", "energy_monitor_card", "power_usage_card", "device_consumption_card", "stat_pill_card", "sensor_card", "weather_card", "vacuum_card", "alarm_card", "camera_card", "pill_card", "room_card", "nuts_card", "card_group", "chore_card"] as const;
@@ -965,6 +966,7 @@ export default function DashboardEditPage() {
   };
 
   function handleAddTile(type: string, entityId: string, titleOverride?: string): string | undefined {
+    if (isWidgetTypeTemporarilyDisabled(type)) return;
     const newId = generateId();
     const newWidget: WidgetConfig = {
       id: newId,
@@ -1179,7 +1181,7 @@ export default function DashboardEditPage() {
                   <div className="flex-1 min-h-0 overflow-y-auto p-5 pt-4">
                   {addTileStep === "type" ? (
                     <div className="grid grid-cols-3 gap-2">
-                      {ADDABLE_WIDGET_TILES.map(({ type, labelKey, Icon }) => (
+                      {ADDABLE_WIDGET_TILES.filter(({ type }) => !isWidgetTypeTemporarilyDisabled(type)).map(({ type, labelKey, Icon }) => (
                         <button
                           key={type}
                           type="button"

--- a/src/app/energy/page.tsx
+++ b/src/app/energy/page.tsx
@@ -34,6 +34,7 @@ import { getEditModeAllowed, getEditModePasscode, checkEditModePasscode } from "
 import { OfflinePill } from "@/components/offline-pill";
 import { useTranslation } from "@/hooks/use-translation";
 import { cn, generateId } from "@/lib/utils";
+import { isWidgetTypeTemporarilyDisabled } from "@/lib/disabled-widget-types";
 import { EditPanelModal } from "./edit-panel";
 
 type LayoutItem = ReactGridLayout.Layout;
@@ -425,6 +426,7 @@ export default function EnergyPage() {
   };
 
   function handleAddTile(type: string, entityId: string, titleOverride?: string): string | undefined {
+    if (isWidgetTypeTemporarilyDisabled(type)) return;
     const newId = generateId();
     const newWidget: WidgetConfig = {
       id: newId,
@@ -998,7 +1000,7 @@ export default function EnergyPage() {
               <div className="flex-1 min-h-0 overflow-y-auto p-5 pt-4">
                 {addTileStep === "type" ? (
                   <div className="grid grid-cols-3 gap-2">
-                    {ADDABLE_WIDGET_TILES.map(({ type, label, Icon }) => (
+                    {ADDABLE_WIDGET_TILES.filter(({ type }) => !isWidgetTypeTemporarilyDisabled(type)).map(({ type, label, Icon }) => (
                       <button
                         key={type}
                         type="button"

--- a/src/lib/disabled-widget-types.test.ts
+++ b/src/lib/disabled-widget-types.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isWidgetTypeTemporarilyDisabled } from "./disabled-widget-types";
+
+describe("temporarily disabled widget types", () => {
+  it("hides the requested add-tile types", () => {
+    expect(isWidgetTypeTemporarilyDisabled("solar_card")).toBe(true);
+    expect(isWidgetTypeTemporarilyDisabled("power_usage_card")).toBe(true);
+    expect(isWidgetTypeTemporarilyDisabled("device_consumption_card")).toBe(true);
+    expect(isWidgetTypeTemporarilyDisabled("sensor_card")).toBe(true);
+    expect(isWidgetTypeTemporarilyDisabled("nuts_card")).toBe(true);
+    expect(isWidgetTypeTemporarilyDisabled("card_group")).toBe(true);
+  });
+
+  it("keeps other addable types available", () => {
+    expect(isWidgetTypeTemporarilyDisabled("light_card")).toBe(false);
+    expect(isWidgetTypeTemporarilyDisabled("text_card")).toBe(false);
+    expect(isWidgetTypeTemporarilyDisabled("climate_card_2")).toBe(false);
+  });
+});

--- a/src/lib/disabled-widget-types.ts
+++ b/src/lib/disabled-widget-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Widget types temporarily hidden from the add-tile picker.
+ * Existing cards of these types still render. Remove a type from this set to re-enable it.
+ */
+export const TEMPORARILY_DISABLED_WIDGET_TYPES = new Set<string>([
+  "solar_card",
+  "power_usage_card",
+  "device_consumption_card",
+  "sensor_card",
+  "nuts_card",
+  "card_group",
+]);
+
+export function isWidgetTypeTemporarilyDisabled(type: string): boolean {
+  return TEMPORARILY_DISABLED_WIDGET_TYPES.has(type);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Temporarily hide these types from the add-tile picker:

- Solar panels
- Power usage
- Usage per device
- Sensor
- Utilities (gas/water)
- Card group

Existing cards of these types still render. Re-enable by removing a type from `TEMPORARILY_DISABLED_WIDGET_TYPES` in `src/lib/disabled-widget-types.ts`.

**Verify**
- Open a dashboard or room in edit mode, click +, confirm those six types are gone
- Confirm light, climate, media, text, etc. are still addable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c21d976-e6e4-472c-b5b0-0526a5aa270d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c21d976-e6e4-472c-b5b0-0526a5aa270d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

