### PR TITLE
Fix screensaver photo transition flashing the dashboard

### DIFF
--- a/src/components/screensaver.tsx
+++ b/src/components/screensaver.tsx
@@ -27,7 +27,17 @@ const DEFAULT_SCREENSAVER_IMAGE = "/default-screensaver.png";
 
 const ACTIVITY_EVENTS = ["mousemove", "mousedown", "keydown", "touchstart", "scroll", "click"] as const;
 const PHOTO_ROTATION_SECONDS = 10;
-const FADE_DURATION_MS = 1500;
+const FADE_DURATION_MS = 1200;
+
+function preloadImage(url: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new window.Image();
+    img.decoding = "async";
+    img.onload = () => resolve();
+    img.onerror = () => resolve();
+    img.src = url;
+  });
+}
 
 function useIdleScreensaver() {
   const [active, setActive] = useState(false);
@@ -408,21 +418,22 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
       headers: { "X-Pexels-Api-Key": pexelsApiKey },
     })
       .then((r) => r.json())
-      .then((data) => {
-        if (data?.imageUrl) {
-          const attr = data.pexelsUrl && data.photographer ? { url: data.pexelsUrl, photographer: data.photographer } : null;
-          setCurrentImage((prev) => {
-            if (prev) {
-              setNextImage(data.imageUrl);
-              setNextAttribution(attr);
-              return prev;
-            }
-            setCurrentAttribution(attr);
-            return data.imageUrl;
-          });
-        } else {
+      .then(async (data) => {
+        if (!data?.imageUrl) {
           setPexelsError(true);
+          return;
         }
+        const attr = data.pexelsUrl && data.photographer ? { url: data.pexelsUrl, photographer: data.photographer } : null;
+        await preloadImage(data.imageUrl);
+        setCurrentImage((prev) => {
+          if (prev) {
+            setNextImage(data.imageUrl);
+            setNextAttribution(attr);
+            return prev;
+          }
+          setCurrentAttribution(attr);
+          return data.imageUrl;
+        });
       })
       .catch(() => setPexelsError(true));
   }, [pexelsApiKey, pexelsQuery]);
@@ -440,8 +451,14 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
 
   useEffect(() => {
     if (!nextImage) return;
-    const start = requestAnimationFrame(() => setIsFading(true));
-    return () => cancelAnimationFrame(start);
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => setIsFading(true));
+    });
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+    };
   }, [nextImage]);
 
   useEffect(() => {
@@ -493,11 +510,11 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
     return () => { if (videoRotateTimer.current) clearTimeout(videoRotateTimer.current); };
   }, [isVideoMode, fetchPexelsVideo]);
 
-  // Fade in next video when available
+  // Fade in next video only after it can play, so we never fade in a blank frame.
   useEffect(() => {
     if (!nextVideoUrl) return;
-    const start = requestAnimationFrame(() => setVideoFading(true));
-    return () => cancelAnimationFrame(start);
+    const fallback = setTimeout(() => setVideoFading(true), 1500);
+    return () => clearTimeout(fallback);
   }, [nextVideoUrl]);
 
   useEffect(() => {
@@ -517,11 +534,8 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
     videoRotateTimer.current = setTimeout(fetchPexelsVideo, VIDEO_MAX_SECONDS * 1000);
   }, [fetchPexelsVideo]);
 
-  const usePexelsRotation = pexelsEnabled && !customBg && pexelsApiKey && pexelsType === "photo";
   const backgroundImage = customBg || currentImage || DEFAULT_SCREENSAVER_IMAGE;
   const useGradient = !isVideoMode && (imageFailed || (pexelsEnabled && !customBg && (pexelsError && !currentImage || !pexelsApiKey)));
-
-  const singleImage = !usePexelsRotation || (!nextImage && !isFading);
   const fadeStyle = { transition: `opacity ${FADE_DURATION_MS}ms ease-in-out` as const };
 
   useEffect(() => {
@@ -543,7 +557,7 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
       tabIndex={0}
       aria-label={t("screensaver.dismiss")}
       className={cn(
-        "fixed inset-0 z-[9999] flex flex-col justify-end p-8 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
+        "fixed inset-0 z-[9999] flex flex-col justify-end overflow-hidden bg-black p-8 cursor-pointer transition-opacity duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
         dismissing && "opacity-0 pointer-events-auto"
       )}
       style={
@@ -569,7 +583,6 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
                   muted
                   playsInline
                   className="absolute inset-0 w-full h-full object-cover"
-                  style={{ opacity: videoFading ? 0 : 1, transition: `opacity ${FADE_DURATION_MS}ms ease-in-out` }}
                   onCanPlay={scheduleVideoRotation}
                   onEnded={fetchPexelsVideo}
                   aria-hidden
@@ -584,39 +597,20 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
                   muted
                   playsInline
                   className="absolute inset-0 w-full h-full object-cover"
-                  style={{ opacity: videoFading ? 1 : 0, transition: `opacity ${FADE_DURATION_MS}ms ease-in-out` }}
+                  style={{
+                    ...fadeStyle,
+                    opacity: videoFading ? 1 : 0,
+                  }}
+                  onCanPlay={() => setVideoFading(true)}
                   aria-hidden
                 />
               )}
-            </>
-          ) : singleImage ? (
-            <>
-              <div
-                className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-                style={{ backgroundImage: `url(${backgroundImage})` }}
-                aria-hidden
-              />
-              <div className="absolute inset-0 pointer-events-none" aria-hidden>
-                <Image
-                  src={backgroundImage}
-                  alt=""
-                  fill
-                  sizes="100vw"
-                  className="sr-only"
-                  onError={() => setImageFailed(true)}
-                  unoptimized
-                />
-              </div>
             </>
           ) : (
             <>
               <div
                 className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-                style={{
-                  ...fadeStyle,
-                  backgroundImage: `url(${currentImage})`,
-                  opacity: isFading ? 0 : 1,
-                }}
+                style={{ backgroundImage: `url(${backgroundImage})` }}
                 aria-hidden
               />
               {nextImage && (
@@ -630,6 +624,17 @@ function ScreensaverOverlay({ onDismiss }: { onDismiss: () => void }) {
                   aria-hidden
                 />
               )}
+              <div className="absolute inset-0 pointer-events-none" aria-hidden>
+                <Image
+                  src={backgroundImage}
+                  alt=""
+                  fill
+                  sizes="100vw"
+                  className="sr-only"
+                  onError={() => setImageFailed(true)}
+                  unoptimized
+                />
+              </div>
             </>
           )}
           <div className="absolute inset-0 bg-black/50" aria-hidden />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When the screensaver switches photos or videos, the old image faded out at the same time as the new one faded in. Because the overlay had no opaque background, the dashboard showed through in the middle of the crossfade.

This change:
- Puts a black full-screen base behind the media
- Fades the next image in on top of the current one (current stays fully opaque)
- Preloads the next photo before starting the fade
- Waits until the next video can play before fading it in

The dashboard should no longer flash between photos.

[Screensaver photo A](https://cursor.com/agents/bc-e5ad1a10-3ab0-4654-850a-56f06c06083f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreensaver-photo-a.png)
[Screensaver photo B](https://cursor.com/agents/bc-e5ad1a10-3ab0-4654-850a-56f06c06083f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreensaver-photo-b.png)
[screensaver-photo-transition.mp4](https://cursor.com/agents/bc-e5ad1a10-3ab0-4654-850a-56f06c06083f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreensaver-photo-transition.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ad1a10-3ab0-4654-850a-56f06c06083f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ad1a10-3ab0-4654-850a-56f06c06083f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

