### PR TITLE
Fix Docker build: light-card layout type error

### DIFF
--- a/src/app/dashboards/[id]/page.tsx
+++ b/src/app/dashboards/[id]/page.tsx
@@ -4967,8 +4967,8 @@ aria-label={t("editPanel.removeCondition")}
                         }),
                       };
                       handleUpdateTile(editingWidgetId, updates);
-                      const newWidgets = widgets.map((w) =>
-                        w.id === editingWidgetId ? { ...w, ...updates } : w
+                      const newWidgets: WidgetConfig[] = widgets.map((w) =>
+                        w.id === editingWidgetId ? ({ ...w, ...updates } as WidgetConfig) : w
                       );
                       saveMutation.mutate({
                         layout,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Docker image build on `main` failed after merging the light-card layout change (PR #14).

`npm run build` died on a TypeScript error in the dashboard editor: spreading the save payload widened `card_layout` from `"horizontal" | "square"` to `string`, which is not assignable to `WidgetConfig`.

This keeps the chosen layout at runtime and asserts the saved widgets as `WidgetConfig[]` so the production build succeeds again.

Verified locally with `npm run build`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ad1a10-3ab0-4654-850a-56f06c06083f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ad1a10-3ab0-4654-850a-56f06c06083f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

